### PR TITLE
Add Retry/Back-off and Environment Profiles Enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,10 @@ jobs:
         runs-on: ubuntu-latest
 
         env:
-            SPOTIFY_API_BASE_URL: ${{ vars.SPOTIFY_API_BASE_URL }}
-            SPOTIFY_CLIENT_ID: ${{ vars.SPOTIFY_CLIENT_ID }}
-            SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+          ENV_PROFILE: production
+          SPOTIFY_API_BASE_URL: ${{ vars.SPOTIFY_API_BASE_URL }}
+          SPOTIFY_CLIENT_ID: ${{ vars.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -842,6 +842,22 @@ files = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "8.5.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687"},
+    {file = "tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -889,4 +905,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "4b244f11d491da99d93e61023da8b16f01ba8524f203862fc421a495257db667"
+content-hash = "2bd04ec098f890539481e9fb5322931ecb127966461ab9de3a02e6e72c8e42fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "python-dotenv (>=1.1.0,<2.0.0)",
     "pydantic (>=2.11.5,<3.0.0)",
-    "pydantic-settings (>=2.9.1,<3.0.0)"
+    "pydantic-settings (>=2.9.1,<3.0.0)",
+    "tenacity (>=8.2.2,<9.0.0)",
 ]
 
 [tool.poetry]

--- a/src/api_testing_framework/config.py
+++ b/src/api_testing_framework/config.py
@@ -1,15 +1,33 @@
+import os
+from typing import List, Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
 
 class Settings(BaseSettings):
     spotify_client_id: str
     spotify_client_secret: str
     spotify_api_base_url: str
 
-    model_config = SettingsConfigDict(env_file=".env")
+    # Pass env_file at instantiation so the class-level default is disabled
+    model_config = SettingsConfigDict(env_file=None)
 
-def get_settings() -> Settings:
+
+def get_settings(env_profile: Optional[str] = None) -> Settings:
     """
-    Read and return a fresh Settings object.
+    Load settings from
+        1) .env.{env_profile} if it exists
+        2) .env               if it exists
+    The profile defaults to the ENV_PROFILE environment variable (or 'dev').
     """
-    return Settings()
+    if env_profile is None:
+        env_profile = os.getenv("ENV_PROFILE", "dev")
+
+    cwd = os.getcwd()
+    candidate_files: List[str] = [
+        os.path.join(cwd, f".env.{env_profile}"),
+        os.path.join(cwd, ".env"),
+    ]
+    env_files = [f for f in candidate_files if os.path.isfile(f)]
+
+    return Settings(_env_file=env_files or None)


### PR DESCRIPTION
# Overview

This PR builds on our existing **test-reporting**, **logging**, **Makefile**, and **CI** setup by adding two core framework features:

1. **Automatic Retries & Exponential Back-off**
2. **Environment "Profiles" for Configuration**

## What's Changed

1. **Retry & Back-off (via Tenacity)**
- **Added Dependency**
    ```toml
    # pyroject.toml
    tenacity = ">=8.2.2,<9.0.0"
    ```

- **APIClient Enhancements**

    In `src/api_testing_framework/client.py`, the `get` and `post` methods are now decorated with Tenacity's `@retry`:

    ```python
    @retry(
        reraise=True,
        stop=stop_after_attempt(3),
        wait=wait_exponential(multiplier=1, min=1, max=10),
        retry=retry_if_exception_type(APIError),
    )
    def (get...): ...
    ```
    - **Retries** up to 3 attempts
    - **Back-off** doubles wait time between failures (max 10s)
    - **Only** on `APIError` (non-2xx or custom exceptions)

    **Benefit:** Makes test resilient to transient HTTP errors (5xx, rate-limits, network blips).

#### 2. Environment Profiles

- **Config Loader Update**

    Replaced top-level `.env`-only logic in `src/api_testing_framework/config.py` with:

    ```python
    def get_settings(env_profile: Optional[str] = None) -> Settings:
        # Picks up ENV_PROFILE (default "dev"), then loads
        #   .env.{profile} -> .env -> os.environ
        return Settings(_env_file=files_list or None)
    ```

- **Multiple Files Supported**
    - `.env.dev`, `.env.staging`, `.env.prod`, etc.
    - Falls back to `.env` if profile-specific file is missing
    - If no files exist, reads actual environment variables

**Benefit:** Easily switch between configurations (e.g. dev vs prod) without code changes.

### How to Verify Locally

1. **Install dependencies**
    ```bash
    make install
    ```
2. **Run unit tests** (with retry decorators in place)
    ```bash
    make test
    ```
3. **Smoke test environment profiles**

    ```bash
    ENV_PROFILE=staging make test
    ```
4. **Generate and view report**

    ```bash
    make report
    make serve-report
    ```

### CI Integration

The existing **.github/workflows/ci.yml** now also benefits:

- **Retries** occur automatically in CI runs.
- **ENV_PROFILE** can be set via `env:` in the workflow to target different test environments.

Example snippet:

```yaml
env:
  ENV_PROFILE: production
  SPOTIFY_API_BASE_URL: ${{ vars.SPOTIFY_API_BASE_URL }}
  SPOTIFY_CLIENT_ID: ${{ vars.SPOTIFY_CLIENT_ID }}
  SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}